### PR TITLE
News page using ENDNOTE 

### DIFF
--- a/app/Livewire/News.php
+++ b/app/Livewire/News.php
@@ -1,0 +1,30 @@
+<?php
+namespace App\Livewire;
+
+use Livewire\Component;
+use Illuminate\Database\Eloquent\Builder;
+use App\Models\Publication;
+
+class News extends Component
+{
+    public $ref_type;
+    public string $searchRef = "";
+    public $publications;
+    public string $searchAuth = "";
+    public $news;
+    public $years;
+
+    public function render()
+    {
+
+        $this -> news = Publication::where('ref_type', 'ilike', '%News%')
+        ->when($this->searchRef !== '', fn(Builder $query) => $query->where('title', 'ilike', '%'. $this->searchRef .'%'))
+        ->when($this->searchAuth !== '', fn(Builder $query) => $query->where('authors', 'ilike', '%'. $this->searchAuth .'%'))
+        -> orderBy('pub_year','DESC')
+          ->get();
+        $this -> years = Publication::select('pub_year')->distinct('pub_year')->orderBy('pub_year', 'DESC')->get();
+        return view('livewire.news', [
+            'news' => $this->news
+        ]);
+    }
+}

--- a/resources/views/content/news.blade.php
+++ b/resources/views/content/news.blade.php
@@ -1,0 +1,10 @@
+<x-guest-layout>
+    <x-slot name="header">
+        <h2 class="text-xl font-semibold leading-tight text-gray-800">
+            {{ __('News and Press Releases') }}
+        </h2>
+    </x-slot>
+
+    <livewire:news  keyref="" />
+
+</x-guest-layout>

--- a/resources/views/layouts/footer.blade.php
+++ b/resources/views/layouts/footer.blade.php
@@ -35,7 +35,7 @@
             <p><a class="hover:font-semibold hover:text-yellow-300 hover:shadow-lg active:text-orange-600 active:shadow-lg"
                     href="/contact">Contact us</a></p>
             <p><a class="hover:font-semibold hover:text-yellow-300 hover:shadow-lg active:text-orange-600 active:shadow-lg"
-                    href="/news">News</a></p>
+                    href="{{ route('content.with.page', ['page' => 'news']) }}">News</a></p>
 
             <p class="inline-block align middle"><a target="_blank"  class="inline-block align middle hover:font-semibold hover:text-yellow-300 hover:shadow-lg active:text-orange-600 active:shadow-lg"
                 href="https://bsky.app/profile/thefarmplatform.bsky.social"> <img src="/logos/bluesky-LOGO.svg" class="inline-block align middle"> thefarmplatform.bsky</a></p>

--- a/resources/views/layouts/navigation-menu.blade.php
+++ b/resources/views/layouts/navigation-menu.blade.php
@@ -1,7 +1,7 @@
 <nav class="border-b-8 border-b-nw-blue-600 bg-nw-blue-50" x-data="{ open: false }">
     <div class="mx-auto px-4 sm:px-6 lg:px-8">{{-- Primary Navigation Menu  --}}
         <div class="flex h-20 justify-between">
-            <div class="flex shrink-0 items-center">{{-- Logo - click on LOGO - GO Home--}}
+            <div class="flex shrink-0 items-center">{{-- Logo - click on LOGO - GO Home --}}
                 <a href="{{ route('home') }}">
                     <x-application-logo class="block h-12" />
                 </a>
@@ -26,7 +26,8 @@
                         <x-dropdown-link href="{{ route('content.with.page', ['page' => 'information']) }}">
                             {{ __('Known Issues and Workarounds') }}
                         </x-dropdown-link>
-                        <x-dropdown-link href="http://exadcon.rothamsted.ac.uk/livedata/collection.jsf?template=weather&node=4826&units=metric">
+                        <x-dropdown-link
+                            href="http://exadcon.rothamsted.ac.uk/livedata/collection.jsf?template=weather&node=4826&units=metric">
                             {{ __('Met Data Live') }}
                         </x-dropdown-link>
 
@@ -51,7 +52,7 @@
                         <x-dropdown-link href="{{ route('content.with.page', ['page' => 'key_findings']) }}">
                             {{ __('Key Findings') }}
                         </x-dropdown-link>
-                        
+
                     </x-slot>
                 </x-dropdown2>
                 <x-dropdown2> {{--  --------- Engage --------- --}}
@@ -97,6 +98,22 @@
                         </x-dropdown-link>
                     </x-slot>
                 </x-dropdown2>
+                <x-dropdown2 href="{{ route('content.with.page', ['page' => 'news']) }}">
+                    <x-slot name="trigger">
+                        {{ __('News') }}
+                    </x-slot>
+                    <x-slot name="content">
+
+                        <x-dropdown-link href="{{ route('content.with.page', ['page' => 'news']) }}">
+                            {{ __('News and Press Releases') }}
+                        </x-dropdown-link>
+                        <x-dropdown-link href="https://bsky.app/profile/thefarmplatform.bsky.social">
+                            {{ __('thefarmplatform.bsky') }}
+                        </x-dropdown-link>
+
+                    </x-slot>
+
+                </x-dropdown2>
                 {{-- ---------  Search that has not been implemented yet !  ---------
                 <x-dropdown2>
                     <x-slot name="trigger">
@@ -129,70 +146,68 @@
                 --}}
                 @if (Route::has('login') && env('FILAMENT_USE') == true) {{--  ---------  Profile Picture of the logged in person --------- --}}
                     @auth
-                            <x-dropdown2>
-                                <x-slot name="trigger">
-                                    @if (Laravel\Jetstream\Jetstream::managesProfilePhotos())
+                        <x-dropdown2>
+                            <x-slot name="trigger">
+                                @if (Laravel\Jetstream\Jetstream::managesProfilePhotos())
+                                    <button
+                                        class="flex rounded-full border-2 border-transparent text-sm transition focus:border-nw-blue-200 focus:outline-none">
+                                        <img class="aspect-square h-16 rounded-full border-4 border-nw-blue-600 object-scale-down p-1"
+                                            src="{{ Auth::user()->profile_photo_url }}" alt="{{ Auth::user()->name }}" />
+                                    </button>
+                                @else
+                                    <span class="inline-flex rounded-md">
                                         <button
-                                            class="flex rounded-full border-2 border-transparent text-sm transition focus:border-nw-blue-200 focus:outline-none">
-                                            <img class="aspect-square h-16 rounded-full border-4 border-nw-blue-600 object-scale-down p-1"
-                                                src="{{ Auth::user()->profile_photo_url }}"
-                                                alt="{{ Auth::user()->name }}" />
+                                            class="inline-flex items-center rounded-md border border-transparent bg-white px-3 py-2 text-sm font-medium leading-4 text-gray-500 transition duration-150 ease-in-out hover:text-gray-700 focus:bg-gray-50 focus:outline-none active:bg-gray-50"
+                                            type="button">
+                                            {{ Auth::user()->name }}
+
+                                            <svg class="-me-0.5 ms-2 h-4 w-4" xmlns="http://www.w3.org/2000/svg"
+                                                fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                                <path stroke-linecap="round" stroke-linejoin="round"
+                                                    d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+                                            </svg>
                                         </button>
-                                    @else
-                                        <span class="inline-flex rounded-md">
-                                            <button
-                                                class="inline-flex items-center rounded-md border border-transparent bg-white px-3 py-2 text-sm font-medium leading-4 text-gray-500 transition duration-150 ease-in-out hover:text-gray-700 focus:bg-gray-50 focus:outline-none active:bg-gray-50"
-                                                type="button">
-                                                {{ Auth::user()->name }}
+                                    </span>
+                                @endif
+                            </x-slot>
+                            <x-slot name="content">
+                                <x-dropdown-link href="{{ route('dashboard') }}">
+                                    {{ __('My Platform') }}
+                                </x-dropdown-link>
+                                <!-- Account Management
+                                                            <div class="block px-4 py-2 text-xs text-gray-400">
+                                                                {{ __('Manage Account') }}
+                                                            </div>
+                                                        -->
 
-                                                <svg class="-me-0.5 ms-2 h-4 w-4" xmlns="http://www.w3.org/2000/svg"
-                                                    fill="none" viewBox="0 0 24 24" stroke-width="1.5"
-                                                    stroke="currentColor">
-                                                    <path stroke-linecap="round" stroke-linejoin="round"
-                                                        d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
-                                                </svg>
-                                            </button>
-                                        </span>
-                                    @endif
-                                </x-slot>
-                                <x-slot name="content">
-                                    <x-dropdown-link href="{{ route('dashboard') }}">
-                                        {{ __('My Platform') }}
+                                <x-dropdown-link href="{{ route('profile.show') }}">
+                                    {{ __('Profile') }}
+                                </x-dropdown-link>
+                                @if (Laravel\Jetstream\Jetstream::hasApiFeatures())
+                                    <x-dropdown-link href="{{ route('api-tokens.index') }}">
+                                        {{ __('API Tokens') }}
                                     </x-dropdown-link>
-                                    <!-- Account Management
-                                                        <div class="block px-4 py-2 text-xs text-gray-400">
-                                                            {{ __('Manage Account') }}
-                                                        </div>
-                                                    -->
+                                @endif
+                                <div class="border-t border-nw-blue-700"></div>
+                                <x-dropdown-link href="{{ env('FILAMENT_PATH') }}">
+                                    {{ __('Admin') }}
+                                </x-dropdown-link>
+                                <div class="border-t border-nw-blue-700"></div>
 
-                                    <x-dropdown-link href="{{ route('profile.show') }}">
-                                        {{ __('Profile') }}
+                                <!-- Authentication -->
+                                <form method="POST" action="{{ route('logout') }}" x-data>
+                                    @csrf
+
+                                    <x-dropdown-link href="{{ route('logout') }}" @click.prevent="$root.submit();">
+                                        {{ __('Log Out') }}
                                     </x-dropdown-link>
-                                    @if (Laravel\Jetstream\Jetstream::hasApiFeatures())
-                                        <x-dropdown-link href="{{ route('api-tokens.index') }}">
-                                            {{ __('API Tokens') }}
-                                        </x-dropdown-link>
-                                    @endif
-                                    <div class="border-t border-nw-blue-700"></div>
-                                    <x-dropdown-link href="{{ env('FILAMENT_PATH') }}">
-                                        {{ __('Admin') }}
-                                    </x-dropdown-link>
-                                    <div class="border-t border-nw-blue-700"></div>
-
-                                    <!-- Authentication -->
-                                    <form method="POST" action="{{ route('logout') }}" x-data>
-                                        @csrf
-
-                                        <x-dropdown-link href="{{ route('logout') }}" @click.prevent="$root.submit();">
-                                            {{ __('Log Out') }}
-                                        </x-dropdown-link>
-                                    </form>
-                                </x-slot>
-                            </x-dropdown2>
+                                </form>
+                            </x-slot>
+                        </x-dropdown2>
                     @endauth
                 @endif
             </div>
-            <div class="-me-2 flex items-center sm:hidden">{{--  Hamberger Menu Don't gorget to update--}}
+            <div class="-me-2 flex items-center sm:hidden">{{--  Hamberger Menu Don't gorget to update --}}
                 <button
                     class="inline-flex items-center justify-center rounded-md p-2 text-gray-400 transition duration-150 ease-in-out hover:bg-gray-100 hover:text-gray-500 focus:bg-gray-100 focus:text-gray-500 focus:outline-none"
                     @click="open = ! open">

--- a/resources/views/livewire/news.blade.php
+++ b/resources/views/livewire/news.blade.php
@@ -1,0 +1,88 @@
+<div>
+    <x-slot name="sub-header">
+        <h2 class="text-xl font-semibold leading-tight text-gray-800">
+            {{ __('News and Press Releases') }}
+        </h2>
+    </x-slot>
+    <div class="flex flex-col items-center justify-between space-y-3 p-4 md:flex-row md:space-x-4 md:space-y-0">
+        <div class="w-full md:w-1/2">
+            <form class="flex items-center">
+                <label class="sr-only" for="simple-search">Search</label>
+                <div class="relative w-full">
+                    <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+                        <svg class="h-5 w-5 text-gray-500 dark:text-gray-400" aria-hidden="true" fill="currentColor"
+                            viewbox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                            <path fill-rule="evenodd"
+                                d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z"
+                                clip-rule="evenodd" />
+                        </svg>
+                    </div>
+                    <input
+                        class="focus:ring-primary-500 focus:border-primary-500 dark:focus:ring-primary-500 dark:focus:border-primary-500 block w-full rounded-lg border border-gray-300 bg-gray-50 p-2 pl-10 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400"
+                        id="simple-search" type="text" wire:model.live="searchRef"
+                        placeholder="Search Title, Keywords..." required="">
+                </div>
+            </form>
+        </div>
+        <div class="w-full md:w-1/2">
+            <form class="flex items-center">
+                <label class="sr-only" for="simple-search">Search</label>
+                <div class="relative w-full">
+                    <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+                        <svg class="h-5 w-5 text-gray-500 dark:text-gray-400" aria-hidden="true" fill="currentColor"
+                            viewbox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                            <path fill-rule="evenodd"
+                                d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z"
+                                clip-rule="evenodd" />
+                        </svg>
+                    </div>
+                    <input
+                        class="focus:ring-primary-500 focus:border-primary-500 dark:focus:ring-primary-500 dark:focus:border-primary-500 block w-full rounded-lg border border-gray-300 bg-gray-50 p-2 pl-10 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400"
+                        id="simple-search" type="text" wire:model.live="searchAuth" placeholder="Search Authors..."
+                        required="">
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <div class="w-100 container mx-auto grid grid-cols-3 gap-4 p-5 ">
+        @foreach ($news as $item)
+
+            <!-- card -->
+            <div class="group w-100 mx-2 mt-4 rounded-lg  bg-gray-200 hover:bg-gray-100 shadow-xl md:flex-row" v-for="card in cards">
+                <!-- media -->
+
+                    <img class="w-full h-48 object-cover overflow-hidden rounded-lg transition-transform transform scale-100" src="{{ $item -> pages }}" />
+
+                <!-- content -->
+                <div class="flex w-full flex-col justify-between px-6 py-4 text-gray-800">
+                    <h3 class="text-lg font-semibold leading-tight"><a
+                            class="text-nw-blue-700 visited:text-amber-900 hover:text-orange-700 active:text-orange-900"
+                            href="{{ $item->url }}">{{ $item->title }}</a>
+                    </h3>
+                    <h4> {{ $item->authors }} ({{ $item->issue_date }})
+                    </h4>
+                    <p class="mt-2 text-sm tracking-wide text-gray-700"> <span
+                            class="italic">{{ $item->journal }}</span>,
+
+                    </p>
+                    <p class="mt-2 text-sm tracking-wide text-gray-700">
+                        {!! $item->abstract !!}
+                    </p>
+
+                    @if ($item->doi)
+                        <p class="mt-2 text-sm tracking-wide text-gray-700"><span class="font-semibold">Paper Cited:
+                            </span><a
+                                class="text-nw-blue-700 visited:text-amber-900 hover:text-orange-700 active:text-orange-900"
+                                href="https://doi.org/{{ $item->doi }}">{{ $item->doi }}
+
+                            </a>
+                        </p>
+                    @endif
+
+                </div>
+            </div><!--/ card-->
+        @endforeach
+    </div>
+
+</div>


### PR DESCRIPTION
Hi; 

We are using the Endnote database to enter news items. 
The news items are usually found on the rothamsted web site. 
A new field in the EN is issue_date

In this test version, the field "pages" has been used to place the URL of the image used by the Rothamsted site to illustrate the news item. We are leveraging that and saving ourselves from work. 
Now, thinking about it, if they change their links, we will have to update that! Is that something we need to worry about? 
We could also just save the image in the usual image folder, on our local instance >>> but that would then need a git update. which is combersome ---- 

we can play a bit longer with styles and so one, I am however eager to merge this to master and worry about style later. 
In this branch: news are ok, but publications are not because I started working on these before the paper branch got merged./ 

I have also added the Menu Item and updated the footer link, 