### PR TITLE
follow on blusky and share on blusky

### DIFF
--- a/resources/views/components/follow-bluesky.blade.php
+++ b/resources/views/components/follow-bluesky.blade.php
@@ -1,0 +1,1 @@
+<a href="https://bsky.app/profile/thefarmplatform.bsky.social"><img src="/logos/bluesky-logo-blue.svg" class="inline-block align middle"> Follow us on Bluesky</a

--- a/resources/views/components/share-on-bluesky.blade.php
+++ b/resources/views/components/share-on-bluesky.blade.php
@@ -1,1 +1,1 @@
-<a href="https://bsky.app/profile/thefarmplatform.bsky.social"><img src="/logos/bluesky-logo-blue.svg" class="inline-block align middle"> Follow us on Bluesky</a
+<a href="https://bsky.app/intent/compose?text={{ $slot }}"><img src="/logos/bluesky-logo-blue.svg" class="inline-block align middle"> Share on BluSky</a

--- a/resources/views/content/advanced_technologies.blade.php
+++ b/resources/views/content/advanced_technologies.blade.php
@@ -1,11 +1,13 @@
 <x-guest-layout>
-
+    @php
+        $title = "North Wyke and the Farm Platform as a Test-Bed For Advances in Sensor Technologies";
+    @endphp
     <x-slot name="header">
         <div class="flex justify-between">
             <h2 class="text-xl font-semibold leading-tight text-gray-800">
-                {{ __('North Wyke and the Farm Platform as a Test-Bed For Advances in Sensor Technologies') }}
+                {{ __($title) }}
             </h2>
-           <!--- <x-share-on-x></x-share-on-x> --->
+           <x-share-on-bluesky>{{$title . ' -  '. app('request')->url() }}</x-share-on-bluesky>
         </div>
     </x-slot>
 

--- a/resources/views/content/news.blade.php
+++ b/resources/views/content/news.blade.php
@@ -4,7 +4,7 @@
             <h2 class="text-xl font-semibold leading-tight text-gray-800">
                 {{ __('News and Press Releases') }}
             </h2>
-            <x-share-on-bluesky></x-share-on-bluesky>
+            <x-follow-bluesky></x-follow-bluesky>
         </div>
     </x-slot>
 


### PR DESCRIPTION
I have looked a bit more into blusky and have found a way to have a "share on bluesky" 
See the example in "advanced technologies" 
This is quite crude and require that  I replace the previsou share-on-x with the new component. 
Also, I am using a variable to add the title and it is used in the title of the page and the URLfor the component,. 
My brain is too dead to find it in the pages model, but I can see that we could do something a lot better if the pages were a proper livewire component. 
To be continued
For now, if that is adequate, I can go and update the desired content pages with a share-on-blusky stuff. Originally, I wanted to have a widget to share on many platforms including emails and so one... This will come in version 2 that I won;t do until after I have done more work on the eRA. 
Cheers