### PR TITLE
ranking order of page display

### DIFF
--- a/app/Filament/Resources/PageResource.php
+++ b/app/Filament/Resources/PageResource.php
@@ -5,7 +5,7 @@ namespace App\Filament\Resources;
 use App\Filament\Resources\PageResource\Pages;
 use App\Filament\Resources\PageResource\RelationManagers;
 use App\Models\Page;
-
+use BcMath\Number;
 use Filament\Forms;
 use Filament\Forms\Components\RichEditor;
 use Filament\Forms\Components\TextInput;
@@ -64,6 +64,7 @@ class PageResource extends Resource
                 ->relationship('tags', 'name')
                 ->preload()
                 ->multiple(),
+                TextInput::make('rank')->numeric()->default(0)->label('Rank (for page display priority)'),
                 Toggle::make('is_focus')->label('On home page'),
                 Toggle::make('is_pinned')->label('On top'),
                 // the fileupload will not work if the disk is on the public directory. When the storage place is available, we can revisit that!
@@ -77,6 +78,8 @@ class PageResource extends Resource
         return $table
                 ->columns([
                     TextColumn::make('title')->wrap(80)->sortable(),
+                    TextColumn::make('rank')->numeric()->sortable()
+                        ->label('Rank (for display priority)'),
                     IconColumn::make('status')
                         ->icon(fn (string $state): string => match ($state) {
                         'Draft' => 'heroicon-o-pencil',

--- a/app/Livewire/Pages.php
+++ b/app/Livewire/Pages.php
@@ -21,10 +21,12 @@ class Pages extends Component
         $this -> pages = Page::where('is_focus', TRUE)
         ->where('is_pinned', FALSE)
         ->where('status',  'Published')
+        ->orderBy('rank', 'asc')
         ->get();
 
         $this -> pinned = Page::where('is_pinned', TRUE)
         ->where('status',  'Published')
+        ->orderBy('rank', 'asc')
         ->get();
 
 

--- a/database/migrations/2025_07_01_143506_add_rank_to_pages_table.php
+++ b/database/migrations/2025_07_01_143506_add_rank_to_pages_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('pages', function (Blueprint $table) {
+            $table->integer('rank')->default(0)->after('title'); 
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('pages', function (Blueprint $table) {
+            $table->dropColumn('rank');
+        });
+    }
+};


### PR DESCRIPTION
This is how we can ran the pages for order of display on the landing page for both pinned at the top and for the cards below. Default value is zero. The rank is added to the pages in the admin panel e.g. for the pinned pages: 1 for Overview, 2 for Where to get Data, 3 for Publications & 4 for Farm Map. The cards below can be ordered in a similar way.